### PR TITLE
Change default of MergeProvider to merge with parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,26 +72,26 @@ render(
 
 ### MergingProvider
 
-Similar to [Provider](#provider), but allows a special `mergeWithParent` prop to allow parent context keys with the same name as those
+Similar to [Provider](#provider), but allows a special `mergeProps` prop to allow parent supplied context keys with the same name as those
 provided by the current `MergingProvider` to be deep merged, instead of replaced.
 
 To learn about `context`, see the [React Docs](https://facebook.github.io/react/docs/context.html).
 
 **Parameters**
 
--   `props` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** All props are exposed as properties in `context`, except `children` and `mergeWithParent`
-    -   `props.mergeWithParent` **([Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array))** If true, deep merges any existing keys in `context` with the newly provided keys, giving precedence to parent values.
-        If `mergeWithParent` is an array of strings, it will deep merge any keys that are present in the array, and missing keys be overriden by the child like [Provider](#provider). (optional, default `false`)
+-   `props` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** All props are exposed as properties in `context`, except `children` and `mergeProps`
+    -   `props.mergeProps` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)?** If not supplied, all supplied props will be merged with keys already in context.  If supplied as an array of strings,
+        it will deep merge any prop names that are present in the array, and missing prop names be overriden by the child like [Provider](#provider).
 
 **Examples**
 
 ```javascript
-import Provider, {MergingProvider} from 'preact-context-provider';
+import Provider, { MergingProvider } from 'preact-context-provider';
 const Demo = (props, context) => {
   console.log(context);  // "{ a: 'b' }"
 };
 
-// without mergeWithParent prop, child keys overwrite parent key values
+// with mergeProps unspecified, all parent context keys are merged with the ones presently supplied, parent values taking precedence
 render(
   <Provider a={key1: 'foo'}>
     <MergingProvider a={key2: 'bar'}>
@@ -99,22 +99,13 @@ render(
     </MergingProvider>
   </Provider>
 );
-// "{ a: { key2: 'bar' } }"
-
-// with mergeWithParent is true, parent key is merged with children, parent values taking precedence
-render(
-  <Provider a={key1: 'foo'}>
-    <MergingProvider mergeWithParent a={key2: 'bar'}>
-      <Demo />
-    </MergingProvider>
-  </Provider>
-);
 // "{ a: { key1: 'foo', key2: 'bar' } }"
 
- // with mergeWithParent is an array, only specified keys are, non-specified keys get their value from current node
+ // when mergeProps is an array, only specified keys are merged, non-specified keys get their value from current node
+// in this example, only the 'a' context key is merged.  'b' is overwritten by the lower node
 render(
   <Provider a={key1: 'foo'} b={key2: 'bar'}>
-    <MergingProvider mergeWithParent={['a']} a={key3: 'baz'} b={key4: 'buz'}>
+    <MergingProvider mergeProps={['a']} a={key3: 'baz'} b={key4: 'buz'}>
       <Demo />
     </MergingProvider>
   </Provider>

--- a/src/index.js
+++ b/src/index.js
@@ -77,23 +77,23 @@ function deepAssign(target, source) {
 
 
 /**
- * Similar to {@link Provider}, but allows a special `mergeWithParent` prop to allow parent context keys with the same name as those
+ * Similar to {@link Provider}, but allows a special `mergeProps` prop to allow parent supplied context keys with the same name as those
  * provided by the current `MergingProvider` to be deep merged, instead of replaced.
  *
  * To learn about `context`, see the [React Docs](https://facebook.github.io/react/docs/context.html).
  *
  * @name MergingProvider
- * @param {Object} props All props are exposed as properties in `context`, except `children` and `mergeWithParent`
- * @param {Boolean|Array} [props.mergeWithParent=false] If true, deep merges any existing keys in `context` with the newly provided keys, giving precedence to parent values.
- * If `mergeWithParent` is an array of strings, it will deep merge any keys that are present in the array, and missing keys be overriden by the child like {@link Provider}.
+ * @param {Object} props All props are exposed as properties in `context`, except `children` and `mergeProps`
+ * @param {Array} [props.mergeProps] If not supplied, all supplied props will be merged with keys already in context.  If supplied as an array of strings,
+ * it will deep merge any prop names that are present in the array, and missing prop names be overriden by the child like {@link Provider}.
  *
  * @example
- * import Provider, {MergingProvider} from 'preact-context-provider';
+ * import Provider, { MergingProvider } from 'preact-context-provider';
  * const Demo = (props, context) => {
  *   console.log(context);  // "{ a: 'b' }"
  * };
  *
- * // without mergeWithParent prop, child keys overwrite parent key values
+ * // with mergeProps unspecified, all parent context keys are merged with the ones presently supplied, parent values taking precedence
  * render(
  *   <Provider a={key1: 'foo'}>
  *     <MergingProvider a={key2: 'bar'}>
@@ -101,22 +101,13 @@ function deepAssign(target, source) {
  *     </MergingProvider>
  *   </Provider>
  * );
- * // "{ a: { key2: 'bar' } }"
- *
- * // with mergeWithParent is true, parent key is merged with children, parent values taking precedence
- * render(
- *   <Provider a={key1: 'foo'}>
- *     <MergingProvider mergeWithParent a={key2: 'bar'}>
- *       <Demo />
- *     </MergingProvider>
- *   </Provider>
- * );
  * // "{ a: { key1: 'foo', key2: 'bar' } }"
  *
- *  // with mergeWithParent is an array, only specified keys are, non-specified keys get their value from current node
+ *  // when mergeProps is an array, only specified keys are merged, non-specified keys get their value from current node
+ * // in this example, only the 'a' context key is merged.  'b' is overwritten by the lower node
  * render(
  *   <Provider a={key1: 'foo'} b={key2: 'bar'}>
- *     <MergingProvider mergeWithParent={['a']} a={key3: 'baz'} b={key4: 'buz'}>
+ *     <MergingProvider mergeProps={['a']} a={key3: 'baz'} b={key4: 'buz'}>
  *       <Demo />
  *     </MergingProvider>
  *   </Provider>
@@ -127,11 +118,11 @@ export class MergingProvider {
 	getChildContext() {
 		let context = {},
 			props=this.props,
-			mergeWithParent=props.mergeWithParent,
-			mergeIsArray=Array.isArray(mergeWithParent);
+			mergeProps = props.mergeProps,
+			mergeIsArray=Array.isArray(mergeProps);
 
-		for (let i in props) if (i !== 'children' && i !== 'mergeWithParent') {
-			context[i] = mergeWithParent && (!mergeIsArray || ~mergeWithParent.indexOf(i)) ? deepAssign(this.context[i], props[i]) : props[i];
+		for (let i in props) if (i !== 'children' && i !== 'mergeProps') {
+			context[i] = (!mergeIsArray || ~mergeProps.indexOf(i)) ? deepAssign(this.context[i], props[i]) : props[i];
 		}
 		return context;
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -39,21 +39,10 @@ describe('preact-context-provider', () => {
 	});
 
 	describe('<MergingProvider />', () => {
-		it('should overwrite higher context keys by default if mergeWithParent is not true', () => {
+		it('should deep merge with higher context keys, giving them precendence, when mergeProps is unset', () => {
 			mount(
 			<MergingProvider {...context}>
-				<MergingProvider a="overwrittenA" >
-					<Spy />
-				</MergingProvider>
-			</MergingProvider>);
-			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] }, { a: 'overwrittenA', b: 'b' });
-
-		});
-
-		it('should deep merge with higher context keys, giving them precendence, when mergeWithParent is true', () => {
-			mount(
-			<MergingProvider {...context}>
-				<MergingProvider mergeWithParent a={{ name: 'notOverwrittenNameA', newProp: 'c' }} b="newB">
+				<MergingProvider a={{ name: 'notOverwrittenNameA', newProp: 'c' }} b="newB">
 					<Spy />
 				</MergingProvider>
 			</MergingProvider>);
@@ -61,10 +50,21 @@ describe('preact-context-provider', () => {
 				{ a: { name: 'a', newProp: 'c' }, b: 'b' });
 		});
 
-		it('should deep merge with selected higher context keys, giving them precendence, when mergeWithParent is an array', () => {
+		it('should deep merge with higher context keys, giving them precendence, when mergeProps is true', () => {
+			mount(
+			<MergingProvider {...context}>
+				<MergingProvider mergeProps a={{ name: 'notOverwrittenNameA', newProp: 'c' }} b="newB">
+					<Spy />
+				</MergingProvider>
+			</MergingProvider>);
+			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] },
+				{ a: { name: 'a', newProp: 'c' }, b: 'b' });
+		});
+
+		it('should deep merge with selected higher context keys, giving them precendence, when mergeProps is an array', () => {
 			mount(
 			<MergingProvider a={{ name: 'a' }} b={{ name: 'b' }} >
-				<MergingProvider mergeWithParent={['a']} a={{ name: 'notOverwrittenNameA', newProp: 'c' }} b={{ newProp: 'd' }} >
+				<MergingProvider mergeProps={['a']} a={{ name: 'notOverwrittenNameA', newProp: 'c' }} b={{ newProp: 'd' }} >
 					<Spy />
 				</MergingProvider>
 			</MergingProvider>);
@@ -75,7 +75,7 @@ describe('preact-context-provider', () => {
 		it('should allow parent to prevent child value from merging by using null value for a key', () => {
 			mount(
 			<MergingProvider a={null} b={{ name: 'b' }} >
-				<MergingProvider mergeWithParent a={{ name: 'a', newProp: 'c' }} b={{ newProp: 'd' }} >
+				<MergingProvider mergeProps a={{ name: 'a', newProp: 'c' }} b={{ newProp: 'd' }} >
 					<Spy />
 				</MergingProvider>
 			</MergingProvider>);
@@ -101,8 +101,8 @@ describe('preact-context-provider', () => {
 		});
 
 		it('should wrap a child with a <MergingProvider> tag with the supplied context, and pass through any props to the child after wrapped', () => {
-			let MergingProvidedSpy = mergingProvide({ ...context, mergeWithParent: true })(Spy);
-			expect(<MergingProvidedSpy foo="bar" />).to.equal(<MergingProvider a={{ name: 'a' }} b="b" mergeWithParent><Spy foo="bar" /></MergingProvider>);
+			let MergingProvidedSpy = mergingProvide({ ...context, mergeProps: true })(Spy);
+			expect(<MergingProvidedSpy foo="bar" />).to.equal(<MergingProvider a={{ name: 'a' }} b="b" mergeProps><Spy foo="bar" /></MergingProvider>);
 		});
 	});
 });


### PR DESCRIPTION
After factoring MergeProvider into it's own component instead of being a prop on Provider, I rethought about it and it makes more sense for it to merge by default instead of not merging by default.  I updated the behavior, docs, and tests appropriately.

I also unpublished 1.1.0 from npm with the no-merge-by-default functionality so that nobody accidentally gets that one.