### PR TITLE
Support for preactX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /npm-debug.log
 .DS_Store
+test-reports

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^6.0.2",
     "npm-run-all": "^4.1.5",
-    "preact": "^8.2.5",
+    "preact": "^10.0.0-beta.2",
     "preact-jsx-chai": "^2.2.1",
     "rimraf": "^2.6.3",
     "rollup": "^1.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default class Provider {
 	}
 
 	render(props) {
-		return props.children[0];
+		return props.children;
 	}
 }
 
@@ -128,7 +128,7 @@ export class MergingProvider {
 	}
 
 	render(props) {
-		return props.children[0];
+		return props.children;
 	}
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,7 @@ describe('preact-context-provider', () => {
 
 		it('should expose props into context', () => {
 			mount(<Provider {...context}><Spy /></Provider>);
-			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] }, context);
+			expect(Spy).to.have.been.calledOnce.and.calledWith({}, context);
 		});
 
 		it('should overwrite higher context keys', () => {
@@ -32,7 +32,7 @@ describe('preact-context-provider', () => {
 						<Spy />
 					</Provider>
 				</Provider>);
-			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] }, { a: 'overwrittenA', b: 'b' });
+			expect(Spy).to.have.been.calledOnce.and.calledWith({}, { a: 'overwrittenA', b: 'b' });
 
 		});
 
@@ -46,7 +46,7 @@ describe('preact-context-provider', () => {
 						<Spy />
 					</MergingProvider>
 				</MergingProvider>);
-			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] },
+			expect(Spy).to.have.been.calledOnce.and.calledWith({},
 				{ a: { name: 'a', newProp: 'c' }, b: 'b' });
 		});
 
@@ -57,7 +57,7 @@ describe('preact-context-provider', () => {
 						<Spy />
 					</MergingProvider>
 				</MergingProvider>);
-			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] },
+			expect(Spy).to.have.been.calledOnce.and.calledWith({},
 				{ a: { name: 'a', newProp: 'c' }, b: 'b' });
 		});
 
@@ -68,7 +68,7 @@ describe('preact-context-provider', () => {
 						<Spy />
 					</MergingProvider>
 				</MergingProvider>);
-			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] },
+			expect(Spy).to.have.been.calledOnce.and.calledWith({},
 				{ a: { name: 'a', newProp: 'c' }, b: { newProp: 'd' } });
 		});
 
@@ -79,7 +79,7 @@ describe('preact-context-provider', () => {
 						<Spy />
 					</MergingProvider>
 				</MergingProvider>);
-			expect(Spy).to.have.been.calledOnce.and.calledWith({ children: [] },
+			expect(Spy).to.have.been.calledOnce.and.calledWith({},
 				{ a: null, b: { name: 'b', newProp: 'd' } });
 		});
 	});


### PR DESCRIPTION
`props.children` is no longer guaranteed to be an Array, so just pass all children through.
Update tests for children no longer guaranteed to be defined.

Depends on https://github.com/developit/preact-jsx-chai/pull/69